### PR TITLE
Add logging for potions obtained from Alchemize and Entropic brew

### DIFF
--- a/src/main/java/runhistoryplus/RunHistoryPlus.java
+++ b/src/main/java/runhistoryplus/RunHistoryPlus.java
@@ -41,6 +41,8 @@ public class RunHistoryPlus implements
         BaseMod.addSaveField(NeowCostsSkippedLog.SaveKey, new NeowCostsSkippedLog());
         BaseMod.addSaveField(PotionDiscardLog.SaveKey, new PotionDiscardLog());
         BaseMod.addSaveField(PotionUseLog.SaveKey, new PotionUseLog());
+        BaseMod.addSaveField(PotionsObtainedAlchemizeLog.SaveKey, new PotionsObtainedAlchemizeLog());
+        BaseMod.addSaveField(PotionsObtainedEntropicBrewLog.SaveKey, new PotionsObtainedEntropicBrewLog());
         BaseMod.addSaveField(RewardsSkippedLog.SaveKey, new RewardsSkippedLog());
         BaseMod.addSaveField(ShopContentsLog.SaveKey, new ShopContentsLog());
 

--- a/src/main/java/runhistoryplus/patches/PotionRunHistoryPatch.java
+++ b/src/main/java/runhistoryplus/patches/PotionRunHistoryPatch.java
@@ -37,8 +37,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class PotionUseAndDiscardRunHistoryPatch {
-    private static final Logger logger = LogManager.getLogger(PotionUseAndDiscardRunHistoryPatch.class.getName());
+public class PotionRunHistoryPatch {
+    private static final Logger logger = LogManager.getLogger(PotionRunHistoryPatch.class.getName());
 
     @SpirePatch(clz = CardCrawlGame.class, method = SpirePatch.CONSTRUCTOR)
     public static class PotionUsePerFloorField {
@@ -274,7 +274,7 @@ public class PotionUseAndDiscardRunHistoryPatch {
             public void edit(MethodCall methodCall) throws CannotCompileException {
                 if (methodCall.getMethodName().equals("obtainPotion")) {
                     methodCall.replace(String.format("{ $_ = $proceed($$); if ($_) %1$s.obtainPotionAlchemizeOrEntropicBrew(this.potion, (String)%2$s.sourceField.get(this)); }",
-                            PotionUseAndDiscardRunHistoryPatch.class.getName(), ActionSourceField.class.getName()));
+                            PotionRunHistoryPatch.class.getName(), ActionSourceField.class.getName()));
                 }
             }
         }
@@ -292,7 +292,7 @@ public class PotionUseAndDiscardRunHistoryPatch {
             public void edit(MethodCall methodCall) throws CannotCompileException {
                 if (methodCall.getMethodName().equals("obtainPotion")) {
                     methodCall.replace(String.format("{ $_ = $proceed($$); if ($_) %1$s.obtainPotionAlchemizeOrEntropicBrew(this.potion, (String)%2$s.sourceField.get(this)); }",
-                            PotionUseAndDiscardRunHistoryPatch.class.getName(), EffectSourceField.class.getName()));
+                            PotionRunHistoryPatch.class.getName(), EffectSourceField.class.getName()));
                 }
             }
         }

--- a/src/main/java/runhistoryplus/patches/PotionUseAndDiscardRunHistoryPatch.java
+++ b/src/main/java/runhistoryplus/patches/PotionUseAndDiscardRunHistoryPatch.java
@@ -204,12 +204,6 @@ public class PotionUseAndDiscardRunHistoryPatch {
             if (isPotionObtained) {
                 CardCrawlGame.metricData.addPotionObtainData(potion);
             }
-            else {
-                List<String> l = PotionDiscardLog.potion_discard_per_floor.get(PotionDiscardLog.potion_discard_per_floor.size() - 1);
-                if (l != null) {
-                    l.add(potion.ID);
-                }
-            }
         }
     }
 }

--- a/src/main/java/runhistoryplus/savables/PotionsObtainedAlchemizeLog.java
+++ b/src/main/java/runhistoryplus/savables/PotionsObtainedAlchemizeLog.java
@@ -1,0 +1,20 @@
+package runhistoryplus.savables;
+
+import basemod.abstracts.CustomSavable;
+
+import java.util.List;
+
+public class PotionsObtainedAlchemizeLog implements CustomSavable<List<List<String>>> {
+    public static final String SaveKey = "potionsObtainedAlchemizeLog";
+    public static List<List<String>> potions_obtained_alchemize;
+
+    @Override
+    public List<List<String>> onSave() {
+        return PotionsObtainedAlchemizeLog.potions_obtained_alchemize;
+    }
+
+    @Override
+    public void onLoad(List<List<String>> potionsObtainedAlchemizeLog) {
+        PotionsObtainedAlchemizeLog.potions_obtained_alchemize = potionsObtainedAlchemizeLog;
+    }
+}

--- a/src/main/java/runhistoryplus/savables/PotionsObtainedEntropicBrewLog.java
+++ b/src/main/java/runhistoryplus/savables/PotionsObtainedEntropicBrewLog.java
@@ -1,0 +1,20 @@
+package runhistoryplus.savables;
+
+import basemod.abstracts.CustomSavable;
+
+import java.util.List;
+
+public class PotionsObtainedEntropicBrewLog implements CustomSavable<List<List<String>>> {
+    public static final String SaveKey = "potionsObtainedEntropicBrewLog";
+    public static List<List<String>> potions_obtained_entropic_brew;
+
+    @Override
+    public List<List<String>> onSave() {
+        return PotionsObtainedEntropicBrewLog.potions_obtained_entropic_brew;
+    }
+
+    @Override
+    public void onLoad(List<List<String>> potionsObtainedEntropicBrewLog) {
+        PotionsObtainedEntropicBrewLog.potions_obtained_entropic_brew = potionsObtainedEntropicBrewLog;
+    }
+}

--- a/src/main/java/runhistoryplus/ui/PotionUseAndDiscardTooltip.java
+++ b/src/main/java/runhistoryplus/ui/PotionUseAndDiscardTooltip.java
@@ -3,7 +3,7 @@ package runhistoryplus.ui;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.helpers.PotionHelper;
 import com.megacrit.cardcrawl.screens.runHistory.RunPathElement;
-import runhistoryplus.patches.PotionUseAndDiscardRunHistoryPatch;
+import runhistoryplus.patches.PotionRunHistoryPatch;
 
 import java.util.List;
 
@@ -13,7 +13,7 @@ public class PotionUseAndDiscardTooltip {
     private static final String TEXT_OBTAIN_TYPE_POTION = TOOLTIP_TEXT[24];
 
     public static void build(RunPathElement element, StringBuilder sb) {
-        List<String> potionsObtainedAlchemize = PotionUseAndDiscardRunHistoryPatch.PotionsObtainedAlchemizeField.potionsObtainedAlchemize.get(element);
+        List<String> potionsObtainedAlchemize = PotionRunHistoryPatch.PotionsObtainedAlchemizeField.potionsObtainedAlchemize.get(element);
         if (potionsObtainedAlchemize != null && !potionsObtainedAlchemize.isEmpty()) {
             if (sb.length() > 0) {
                 sb.append(" NL ");
@@ -24,7 +24,7 @@ public class PotionUseAndDiscardTooltip {
             }
         }
 
-        List<String> potionsObtainedEntropicBrew = PotionUseAndDiscardRunHistoryPatch.PotionsObtainedEntropicBrewField.potionsObtainedEntropicBrew.get(element);
+        List<String> potionsObtainedEntropicBrew = PotionRunHistoryPatch.PotionsObtainedEntropicBrewField.potionsObtainedEntropicBrew.get(element);
         if (potionsObtainedEntropicBrew != null && !potionsObtainedEntropicBrew.isEmpty()) {
             if (sb.length() > 0) {
                 sb.append(" NL ");
@@ -35,7 +35,7 @@ public class PotionUseAndDiscardTooltip {
             }
         }
 
-        List<String> potionUse = PotionUseAndDiscardRunHistoryPatch.PotionUseField.potionUse.get(element);
+        List<String> potionUse = PotionRunHistoryPatch.PotionUseField.potionUse.get(element);
         if (potionUse != null && !potionUse.isEmpty()) {
             if (sb.length() > 0) {
                 sb.append(" NL ");
@@ -46,7 +46,7 @@ public class PotionUseAndDiscardTooltip {
             }
         }
 
-        List<String> potionDiscard = PotionUseAndDiscardRunHistoryPatch.PotionDiscardField.potionDiscard.get(element);
+        List<String> potionDiscard = PotionRunHistoryPatch.PotionDiscardField.potionDiscard.get(element);
         if (potionDiscard != null && !potionDiscard.isEmpty()) {
             if (sb.length() > 0) {
                 sb.append(" NL ");

--- a/src/main/java/runhistoryplus/ui/PotionUseAndDiscardTooltip.java
+++ b/src/main/java/runhistoryplus/ui/PotionUseAndDiscardTooltip.java
@@ -13,6 +13,28 @@ public class PotionUseAndDiscardTooltip {
     private static final String TEXT_OBTAIN_TYPE_POTION = TOOLTIP_TEXT[24];
 
     public static void build(RunPathElement element, StringBuilder sb) {
+        List<String> potionsObtainedAlchemize = PotionUseAndDiscardRunHistoryPatch.PotionsObtainedAlchemizeField.potionsObtainedAlchemize.get(element);
+        if (potionsObtainedAlchemize != null && !potionsObtainedAlchemize.isEmpty()) {
+            if (sb.length() > 0) {
+                sb.append(" NL ");
+            }
+            sb.append(TEXT[2]);
+            for (String potionID : potionsObtainedAlchemize) {
+                sb.append(" NL ").append(" TAB ").append(TEXT_OBTAIN_TYPE_POTION).append(PotionHelper.getPotion(potionID).name);
+            }
+        }
+
+        List<String> potionsObtainedEntropicBrew = PotionUseAndDiscardRunHistoryPatch.PotionsObtainedEntropicBrewField.potionsObtainedEntropicBrew.get(element);
+        if (potionsObtainedEntropicBrew != null && !potionsObtainedEntropicBrew.isEmpty()) {
+            if (sb.length() > 0) {
+                sb.append(" NL ");
+            }
+            sb.append(TEXT[3]);
+            for (String potionID : potionsObtainedEntropicBrew) {
+                sb.append(" NL ").append(" TAB ").append(TEXT_OBTAIN_TYPE_POTION).append(PotionHelper.getPotion(potionID).name);
+            }
+        }
+
         List<String> potionUse = PotionUseAndDiscardRunHistoryPatch.PotionUseField.potionUse.get(element);
         if (potionUse != null && !potionUse.isEmpty()) {
             if (sb.length() > 0) {

--- a/src/main/resources/runhistoryplus/localization/eng/RunHistoryPlus-ui.json
+++ b/src/main/resources/runhistoryplus/localization/eng/RunHistoryPlus-ui.json
@@ -16,7 +16,9 @@
   "RunHistoryPlus:PotionUseAndDiscard": {
     "TEXT": [
       "#yUsed: ",
-      "#yDiscarded: "
+      "#yDiscarded: ",
+      "#yObtained #yfrom #yAlchemize:",
+      "#yObtained #yfrom #yEntropic #yBrew:"
     ]
   },
   "RunHistoryPlus:BlueKeyRelicSkipped": {


### PR DESCRIPTION
I'm not very happy with the patch, but I don't know, if there is a better way to get the return value from the call to `AbstractPlayer.obtainPotion()` and then add the logging code afterwards.

If multiple potions were obtained on a single floor, the tooltip shows them all on a single line (only separated by `TAB`), this behavior is already in vanilla (e. g. Lab event)

TODO:
- [x] remove logging of potions skipped because there are no empty potion slots
- [x] add log fields for potions obtained from Alchemize and Entropic Brew (same format as `potions_obtained` or plain array?)
- [x] change logging to use the new fields
- [x] add logging in `ObtainPotionEffect` (tbd: care about mods potentially using this for other things beside entropic brew?)
- [x] display new data in the floor tooltip on the run history screen