### PR TITLE
Show final value for Genetic Algorithm and Ritual Dagger in card popup on the run history screen

### DIFF
--- a/src/main/java/runhistoryplus/patches/ImprovableCardRunHistoryPatch.java
+++ b/src/main/java/runhistoryplus/patches/ImprovableCardRunHistoryPatch.java
@@ -1,0 +1,60 @@
+package runhistoryplus.patches;
+
+import basemod.ReflectionHacks;
+import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.blue.GeneticAlgorithm;
+import com.megacrit.cardcrawl.cards.colorless.RitualDagger;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.metrics.Metrics;
+import com.megacrit.cardcrawl.monsters.MonsterGroup;
+import com.megacrit.cardcrawl.screens.stats.RunData;
+import javassist.CannotCompileException;
+import javassist.NotFoundException;
+import javassist.CtBehavior;
+import javassist.CtClass;
+import javassist.CtField;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ImprovableCardRunHistoryPatch {
+    private static Map<String, List<Integer>> improvableCardsLog;
+    private static final ArrayList<String> improvableCards = new ArrayList<String>() {{
+        add(GeneticAlgorithm.ID);
+        add(RitualDagger.ID);
+    }};
+
+    @SpirePatch(clz = CardCrawlGame.class, method = SpirePatch.CONSTRUCTOR)
+    public static class ImprovableCardsField {
+        @SpireRawPatch
+        public static void addImprovableCardsField(CtBehavior ctBehavior) throws NotFoundException, CannotCompileException {
+            CtClass runData = ctBehavior.getDeclaringClass().getClassPool().get(RunData.class.getName());
+            String fieldSource = "public java.util.Map improvable_cards;";
+            CtField field = CtField.make(fieldSource, runData);
+            runData.addField(field);
+        }
+    }
+
+    @SpirePatch(clz = Metrics.class, method = "gatherAllData")
+    public static class GatherAllDataPatch {
+        @SpirePostfixPatch
+        public static void gatherAllDataPatch(Metrics __instance, boolean death, boolean trueVictor, MonsterGroup monsters) {
+            improvableCardsLog = new HashMap<>();
+            for (final AbstractCard card: AbstractDungeon.player.masterDeck.group) {
+                if (improvableCards.contains(card.cardID)) {
+                    String metricId = card.getMetricID();
+                    if (!improvableCardsLog.containsKey(metricId)) {
+                        improvableCardsLog.put(metricId, new ArrayList<Integer>());
+                    }
+                    improvableCardsLog.get(metricId).add(card.misc);
+                }
+            }
+            ReflectionHacks.privateMethod(Metrics.class, "addData", Object.class, Object.class)
+                    .invoke(__instance, "improvable_cards", improvableCardsLog);
+        }
+    }
+}

--- a/src/main/java/runhistoryplus/patches/ImprovableCardRunHistoryPatch.java
+++ b/src/main/java/runhistoryplus/patches/ImprovableCardRunHistoryPatch.java
@@ -2,13 +2,17 @@ package runhistoryplus.patches;
 
 import basemod.ReflectionHacks;
 import com.evacipated.cardcrawl.modthespire.lib.*;
+import com.evacipated.cardcrawl.modthespire.patcher.PatchingException;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.cards.blue.GeneticAlgorithm;
 import com.megacrit.cardcrawl.cards.colorless.RitualDagger;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.metrics.Metrics;
 import com.megacrit.cardcrawl.monsters.MonsterGroup;
+import com.megacrit.cardcrawl.screens.runHistory.RunHistoryScreen;
+import com.megacrit.cardcrawl.screens.runHistory.TinyCard;
 import com.megacrit.cardcrawl.screens.stats.RunData;
 import javassist.CannotCompileException;
 import javassist.NotFoundException;
@@ -16,7 +20,9 @@ import javassist.CtBehavior;
 import javassist.CtClass;
 import javassist.CtField;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,15 +52,37 @@ public class ImprovableCardRunHistoryPatch {
             improvableCardsLog = new HashMap<>();
             for (final AbstractCard card: AbstractDungeon.player.masterDeck.group) {
                 if (improvableCards.contains(card.cardID)) {
-                    String metricId = card.getMetricID();
-                    if (!improvableCardsLog.containsKey(metricId)) {
-                        improvableCardsLog.put(metricId, new ArrayList<Integer>());
+                    if (!improvableCardsLog.containsKey(card.name)) {
+                        improvableCardsLog.put(card.name, new ArrayList<>());
                     }
-                    improvableCardsLog.get(metricId).add(card.misc);
+                    improvableCardsLog.get(card.name).add(card.misc);
                 }
             }
             ReflectionHacks.privateMethod(Metrics.class, "addData", Object.class, Object.class)
                     .invoke(__instance, "improvable_cards", improvableCardsLog);
+        }
+    }
+
+    @SpirePatch(clz = RunHistoryScreen.class, method = "update")
+    public static class RunHistoryScreenUpdatePatch {
+        @SpireInsertPatch(locator = Locator.class, localvars = "addMe")
+        public static void updateCardsWithFinalValues(RunHistoryScreen __instance, RunData ___viewedRun, TinyCard addMe) throws NoSuchFieldException, IllegalAccessException {
+            if (improvableCards.contains(addMe.card.cardID)) {
+                Field improvableCardsField = ___viewedRun.getClass().getField("improvable_cards");
+                Map<String, List<Double>> improvableCardsLog = (Map<String, List<Double>>)improvableCardsField.get(___viewedRun);
+                if (improvableCardsLog != null && improvableCardsLog.containsKey(addMe.card.name)) {
+                    Integer value = Collections.max(improvableCardsLog.get(addMe.card.name)).intValue();
+                    addMe.card.baseDamage = value;
+                    addMe.card.baseBlock = value;
+                }
+            }
+        }
+
+        public static class Locator extends SpireInsertLocator {
+            public int[] Locate(CtBehavior ctMethodToPatch) throws CannotCompileException, PatchingException {
+                Matcher matcher = new Matcher.MethodCallMatcher(CardGroup.class, "addToTop");
+                return LineFinder.findInOrder(ctMethodToPatch, new ArrayList<>(), matcher);
+            }
         }
     }
 }

--- a/src/main/java/runhistoryplus/patches/ImprovableCardRunHistoryPatch.java
+++ b/src/main/java/runhistoryplus/patches/ImprovableCardRunHistoryPatch.java
@@ -32,6 +32,7 @@ public class ImprovableCardRunHistoryPatch {
         add(GeneticAlgorithm.ID);
         add(RitualDagger.ID);
     }};
+    private static final String[] TEXT = CardCrawlGame.languagePack.getUIString("RunHistoryPlus:ImprovableCards").TEXT;
 
     @SpirePatch(clz = CardCrawlGame.class, method = SpirePatch.CONSTRUCTOR)
     public static class ImprovableCardsField {
@@ -75,6 +76,19 @@ public class ImprovableCardRunHistoryPatch {
                     Integer value = Collections.max(improvableCardsLog.get(metricID)).intValue();
                     addMe.card.baseDamage = value;
                     addMe.card.baseBlock = value;
+                    if (!addMe.card.rawDescription.contains(TEXT[0])) {
+                        ArrayList<Integer> values = new ArrayList<>();
+                        for (Double f : improvableCardsLog.get(metricID)) {
+                            values.add(f.intValue());
+                        }
+                        Collections.sort(values);
+                        addMe.card.rawDescription += TEXT[0] + values.toString();
+                        System.out.println(addMe.card.rawDescription);
+                        addMe.card.initializeDescription();
+                        for (int i = 0; i < addMe.card.description.size(); ++i) {
+                            System.out.println(addMe.card.description.get(i).text);
+                        }
+                    }
                 }
             }
         }
@@ -84,6 +98,15 @@ public class ImprovableCardRunHistoryPatch {
                 Matcher matcher = new Matcher.MethodCallMatcher(CardGroup.class, "addToTop");
                 return LineFinder.findInOrder(ctMethodToPatch, new ArrayList<>(), matcher);
             }
+        }
+    }
+
+    @SpirePatch(clz = AbstractCard.class, method = "makeStatEquivalentCopy")
+    public static class AbstractCardCopyDescriptionPatch {
+        @SpirePostfixPatch
+        public static AbstractCard copyWithdescription(AbstractCard card, AbstractCard __instance) {
+            card.description = __instance.description;
+            return card;
         }
     }
 }

--- a/src/main/java/runhistoryplus/patches/ImprovableCardRunHistoryPatch.java
+++ b/src/main/java/runhistoryplus/patches/ImprovableCardRunHistoryPatch.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 
 public class ImprovableCardRunHistoryPatch {
-    private static Map<String, List<Integer>> improvableCardsLog;
     private static final ArrayList<String> improvableCards = new ArrayList<String>() {{
         add(GeneticAlgorithm.ID);
         add(RitualDagger.ID);
@@ -49,13 +48,14 @@ public class ImprovableCardRunHistoryPatch {
     public static class GatherAllDataPatch {
         @SpirePostfixPatch
         public static void gatherAllDataPatch(Metrics __instance, boolean death, boolean trueVictor, MonsterGroup monsters) {
-            improvableCardsLog = new HashMap<>();
+            Map<String, List<Integer>> improvableCardsLog = new HashMap<>();
             for (final AbstractCard card: AbstractDungeon.player.masterDeck.group) {
                 if (improvableCards.contains(card.cardID)) {
-                    if (!improvableCardsLog.containsKey(card.name)) {
-                        improvableCardsLog.put(card.name, new ArrayList<>());
+                    String metricID = card.getMetricID();
+                    if (!improvableCardsLog.containsKey(metricID)) {
+                        improvableCardsLog.put(metricID, new ArrayList<>());
                     }
-                    improvableCardsLog.get(card.name).add(card.misc);
+                    improvableCardsLog.get(metricID).add(card.misc);
                 }
             }
             ReflectionHacks.privateMethod(Metrics.class, "addData", Object.class, Object.class)
@@ -70,8 +70,9 @@ public class ImprovableCardRunHistoryPatch {
             if (improvableCards.contains(addMe.card.cardID)) {
                 Field improvableCardsField = ___viewedRun.getClass().getField("improvable_cards");
                 Map<String, List<Double>> improvableCardsLog = (Map<String, List<Double>>)improvableCardsField.get(___viewedRun);
-                if (improvableCardsLog != null && improvableCardsLog.containsKey(addMe.card.name)) {
-                    Integer value = Collections.max(improvableCardsLog.get(addMe.card.name)).intValue();
+                String metricID = addMe.card.getMetricID();
+                if (improvableCardsLog != null && improvableCardsLog.containsKey(metricID)) {
+                    Integer value = Collections.max(improvableCardsLog.get(metricID)).intValue();
                     addMe.card.baseDamage = value;
                     addMe.card.baseBlock = value;
                 }

--- a/src/main/java/runhistoryplus/patches/ImprovableCardRunHistoryPatch.java
+++ b/src/main/java/runhistoryplus/patches/ImprovableCardRunHistoryPatch.java
@@ -3,6 +3,7 @@ package runhistoryplus.patches;
 import basemod.ReflectionHacks;
 import com.evacipated.cardcrawl.modthespire.lib.*;
 import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.cards.CardGroup;
 import com.megacrit.cardcrawl.cards.blue.GeneticAlgorithm;
 import com.megacrit.cardcrawl.cards.colorless.RitualDagger;
 import com.megacrit.cardcrawl.core.CardCrawlGame;
@@ -11,6 +12,7 @@ import com.megacrit.cardcrawl.metrics.Metrics;
 import com.megacrit.cardcrawl.monsters.MonsterGroup;
 import com.megacrit.cardcrawl.screens.runHistory.RunHistoryScreen;
 import com.megacrit.cardcrawl.screens.runHistory.TinyCard;
+import com.megacrit.cardcrawl.screens.SingleCardViewPopup;
 import com.megacrit.cardcrawl.screens.stats.RunData;
 import javassist.CannotCompileException;
 import javassist.NotFoundException;
@@ -88,12 +90,12 @@ public class ImprovableCardRunHistoryPatch {
         }
     }
 
-    @SpirePatch(clz = AbstractCard.class, method = "makeStatEquivalentCopy")
-    public static class AbstractCardCopyDescriptionPatch {
+    @SpirePatch(clz = SingleCardViewPopup.class, method = "open", paramtypez={AbstractCard.class, CardGroup.class})
+    public static class SingleCardViewPopupCopyCardDescriptionPatch {
         @SpirePostfixPatch
-        public static AbstractCard copyWithdescription(AbstractCard card, AbstractCard __instance) {
-            card.description = __instance.description;
-            return card;
+        public static void copyDescription(SingleCardViewPopup __instance, AbstractCard card) {
+            AbstractCard copy = ReflectionHacks.getPrivate(__instance, SingleCardViewPopup.class, "card");
+            copy.description = card.description;
         }
     }
 }

--- a/src/main/resources/runhistoryplus/localization/eng/RunHistoryPlus-ui.json
+++ b/src/main/resources/runhistoryplus/localization/eng/RunHistoryPlus-ui.json
@@ -66,5 +66,10 @@
       "If checked, run history will check if any of the selected Relics were obtained in the run. NL NL If unchecked, run history will require that all of the selected Relics were obtained in the run.",
       "Close"
     ]
+  },
+  "RunHistoryPlus:ImprovableCards": {
+    "TEXT": [
+      " NL Values: "
+    ]
   }
 }


### PR DESCRIPTION
If multiples of the same card were in the deck, all values are recorded, but only the highest one is shown.

`updateCardsWithFinalValues` feels still very hacky, The values seem to be loaded as type `Double` although they don't contain decimals in the run file.
There is no common method to calculate the damage/block values for both cards, so I just set both `baseBlock` and `baseDamage`.